### PR TITLE
Small typo

### DIFF
--- a/src/Control/Lens/Tutorial.hs
+++ b/src/Control/Lens/Tutorial.hs
@@ -713,7 +713,7 @@ import Data.Monoid (Monoid)
 
     ... can be specialized to use @(`Const` b)@ in place of @f@:
 
-> (b -> Const b b) -> (a -> Const b b)
+> (b -> Const b b) -> (a -> Const b a)
 
 
     ... making it a valid argument to `view`.


### PR DESCRIPTION
Another `Const b b` which should read `Const b a`. This time I performed a search. It should be the last of its kind.
