### PR TITLE
Update code on `fundamental` section of `view`

### DIFF
--- a/src/Control/Lens/Tutorial.hs
+++ b/src/Control/Lens/Tutorial.hs
@@ -343,7 +343,7 @@ import Data.Monoid (Monoid)
     `view` and `over` are fundamental because they distribute over lens
     composition:
 
-> view (lens1 . lens2) = (view lens2) . (view lens1)
+> view (lens1 . lens2) = (view lens1) . (view lens2)
 >
 > view id = id
 


### PR DESCRIPTION
When `view` distributes over lens composition, we should not "switch" the order we're viewing things in.